### PR TITLE
Handle the latest version of the guide and uop.info

### DIFF
--- a/lib/guide/loader.py
+++ b/lib/guide/loader.py
@@ -67,7 +67,7 @@ class Builder(object):
             e.operation = None
 
         e.include = self.children['header'].text
-        e.rettype = self.intrinsic.attrib['rettype']
+        e.rettype = self.children['return'].attrib['type']
 
         e.instructions = []
         for instr in self.instructions:
@@ -75,7 +75,8 @@ class Builder(object):
             form = instr.attrib.get('form', '') # might not be present
             e.instructions.append((name, form))
 
-        tmp = ['%s %s' % (item.attrib['type'], item.attrib['varname']) for item in self.parameters]
+        tmp = ['%s %s' % (item.attrib['type'], item.attrib.get('varname', ''))
+               for item in self.parameters]
         e.arguments = ', '.join(tmp)
         if e.arguments == 'void ': # that's silly
             e.arguments = ''

--- a/lib/man/uops.py
+++ b/lib/man/uops.py
@@ -37,7 +37,7 @@ class Generate(object):
                     data = {
                         'architecture'  : arch_fmt,
                         'latency'       : format_latency(measurement.latency),
-                        'throughput'    : measurement.throughput,
+                        'throughput'    : format_throughput(measurement.throughput),
                         'uops'          : measurement.total_uops,
                         'uops_details'  : format_port_details(measurement.uops_details),
                     }
@@ -117,3 +117,9 @@ def format_port_details(port_details):
 
     return ' '.join('p%s:%d' % (pd.ports, pd.uops) for pd in port_details)
 
+
+def format_throughput(throughput):
+    if throughput is None:
+        return '\-'
+
+    return '%0.2f' % throughput

--- a/lib/man/uops_patterns.py
+++ b/lib/man/uops_patterns.py
@@ -21,10 +21,10 @@ ARCH_TABLE_HEADER_SHORT="""%s
 Architecture\tLatency\tThroughput\tuops
 """
 
-ARCH_TABLE_ROW_LONG="""%(architecture)s\t%(latency)s\t%(throughput)0.2f\t%(uops)d\t%(uops_details)s
+ARCH_TABLE_ROW_LONG="""%(architecture)s\t%(latency)s\t%(throughput)s\t%(uops)d\t%(uops_details)s
 """
 
-ARCH_TABLE_ROW_SHORT="""%(architecture)s\t%(latency)s\t%(throughput)0.2f\t%(uops)d
+ARCH_TABLE_ROW_SHORT="""%(architecture)s\t%(latency)s\t%(throughput)s\t%(uops)d
 """
 
 ARCH_TABLE_END=""".TE

--- a/lib/uops/loader.py
+++ b/lib/uops/loader.py
@@ -97,7 +97,7 @@ def parse_measurements(architecture):
 
 def parse_measurement(measurement):
     data = Measurement()
-    data.throughput   = optional_float(measurement.attrib, 'TP')
+    data.throughput   = optional_float(measurement.attrib, 'TP_ports')
     data.total_uops   = int(measurement.attrib['uops'])
     data.uops_details = parse_ports(measurement)
 


### PR DESCRIPTION
Changes to match the latest Intel guide XML format:

  * Intrinsic return types are now in a `<return type="..." />` element.
  * The varname attribute is now omitted for void parameters.

Changes to match the latest uop.info XML format:

  * There are now several flavors of throughput reported for measurements. I can't find a definition of what the different values mean, however `TP_ports` seems more likely to be what we want than any of the `TP_loop` or `TP_unrolled` variants.
  * Some throughput numbers are now absent, so report '-' in the table.